### PR TITLE
fix: resolve TypeScript compile error in settings.ts

### DIFF
--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -26,7 +26,7 @@ export async function loadSettings(): Promise<SettingsType> {
 
       // Only override default values if they exist in storage
       if (result[SETTINGS_KEYS.ENABLED] !== undefined) {
-        settings.enabled = result[SETTINGS_KEYS.ENABLED];
+        settings.enabled = result[SETTINGS_KEYS.ENABLED] === true;
       }
 
       resolve(settings);


### PR DESCRIPTION
## Summary
- `chrome.storage.local.get()` の戻り値は `Record<string, unknown>` のため、`settings.enabled` への直接代入で TS2322 エラーが発生していた
- `=== true` で明示的に boolean へ変換することで修正

## Test plan
- [x] `pnpm run compile` がエラーなしで通ること
- [x] `pnpm run test` で既存テストが pass すること（ValueCommerce の外部通信テストはフラキー）