### PR TITLE
fix: remove Amazon linkCode affiliate parameter

### DIFF
--- a/src/core/amazon/getAmazonOriginal.spec.ts
+++ b/src/core/amazon/getAmazonOriginal.spec.ts
@@ -1,0 +1,37 @@
+import { getAmazonOriginal } from "./getAmazonOriginal";
+
+describe("getAmazonOriginal", () => {
+  it("should remove tag parameter", async () => {
+    const url = "https://www.amazon.co.jp/dp/B0DJDZRW18?tag=sakurachecker-22";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.co.jp/dp/B0DJDZRW18");
+  });
+
+  it("should remove both tag and linkCode parameters", async () => {
+    const url =
+      "https://www.amazon.co.jp/dp/B0DJDZRW18?tag=sakurachecker-22&linkCode=ogi&th=1&psc=1";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1");
+  });
+
+  it("should remove tag when it is not the first parameter", async () => {
+    const url =
+      "https://www.amazon.co.jp/gp/product/B08JLZV7G1?ref=nosim&tag=example-22&linkCode=ogi";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.co.jp/gp/product/B08JLZV7G1?ref=nosim");
+  });
+
+  it("should resolve amzn.to short links via redirect", async () => {
+    const redirectTarget = "https://www.amazon.co.jp/dp/B08JLZV7G1?tag=test-22&linkCode=ogi";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, {
+        status: 301,
+        headers: { location: redirectTarget },
+      }),
+    );
+    // resolveRedirects follows the 301 and returns the location
+    // Then getAmazonOriginal strips tag and linkCode
+    const result = await getAmazonOriginal("https://amzn.to/3abcDEF");
+    expect(result).toBe("https://www.amazon.co.jp/dp/B08JLZV7G1");
+  });
+});

--- a/src/core/amazon/getAmazonOriginal.ts
+++ b/src/core/amazon/getAmazonOriginal.ts
@@ -10,8 +10,9 @@ export async function getAmazonOriginal(url: string): Promise<string> {
     url = await resolveRedirects(url);
   }
 
-  // Remove the tag parameter
+  // Remove affiliate parameters
   const urlObj = new URL(url);
   urlObj.searchParams.delete("tag");
+  urlObj.searchParams.delete("linkCode");
   return urlObj.toString();
 }


### PR DESCRIPTION
## Summary
- Amazon アフィリエイトリンクから `tag` に加えて `linkCode` パラメータも除去するよう修正
- sakura-checker の `?tag=sakurachecker-22&linkCode=ogi` が完全にクリーンになる
- `getAmazonOriginal.spec.ts` を新規追加（4テストケース）

## Test plan
- [x] `pnpm run compile` pass
- [x] `pnpm vitest run src/core/amazon/` 全9テスト pass