### PR TITLE
fix: prevent MutationObserver from re-sending resolved URLs

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -9,8 +9,8 @@ function applyResolvedLinks(anchors: HTMLAnchorElement[]) {
   for (const anchor of anchors) {
     const resolved = resolvedCache.get(anchor.href);
     if (resolved && resolved !== anchor.href) {
+      resolvedCache.set(resolved, resolved);
       anchor.href = resolved;
-    } else if (resolved) {
     }
   }
 }


### PR DESCRIPTION
## Summary
- リンク置換後に MutationObserver が変更を検知し、解決済みURLを再度 background に送信していた問題を修正
- 解決済みURLを自己参照エントリとしてキャッシュに追加することで、不要な2回目の通信を防止
- sakura-checker のような多数のアフィリエイトリンクがあるページでの性能改善

## Test plan
- [x] `pnpm run compile` pass
- [x] テスト 76/77 pass（1件は既存の外部通信フラキーテスト）