### PR TITLE
fix: extend purifyResolvedUrl to remove Amazon affiliate params

### DIFF
--- a/src/core/utils/purifyResolvedUrl.spec.ts
+++ b/src/core/utils/purifyResolvedUrl.spec.ts
@@ -16,4 +16,22 @@ describe("purifyResolvedUrl", () => {
     const input = "https://www.rakuten.co.jp/item?foo=bar";
     expect(purifyResolvedUrl(input)).toBe(input);
   });
+
+  it("removes tag and linkCode from amazon domains", () => {
+    const input =
+      "https://www.amazon.co.jp/dp/B0DJDZRW18?tag=sakurachecker-22&linkCode=ogi&th=1&psc=1";
+    expect(purifyResolvedUrl(input)).toBe(
+      "https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1",
+    );
+  });
+
+  it("keeps non-amazon domains untouched for amazon params", () => {
+    const input = "https://example.com/?tag=test-22&linkCode=ogi";
+    expect(purifyResolvedUrl(input)).toBe(input);
+  });
+
+  it("returns original amazon url when no affiliate params exist", () => {
+    const input = "https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1";
+    expect(purifyResolvedUrl(input)).toBe(input);
+  });
 });

--- a/src/core/utils/purifyResolvedUrl.ts
+++ b/src/core/utils/purifyResolvedUrl.ts
@@ -4,23 +4,41 @@ function isRakutenDomain(hostname: string): boolean {
   return hostname === "rakuten.co.jp" || hostname.endsWith(rakutenHostSuffix);
 }
 
-function purifyResolvedRakutenUrl(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    if (!isRakutenDomain(urlObj.hostname)) return url;
+function isAmazonDomain(hostname: string): boolean {
+  return hostname === "amazon.co.jp" || hostname.endsWith(".amazon.co.jp");
+}
 
-    const hasScid = urlObj.searchParams.has("scid");
-    const hasSc2id = urlObj.searchParams.has("sc2id");
-    if (!hasScid && !hasSc2id) return url;
+function purifyResolvedRakutenUrl(url: string, urlObj: URL): string {
+  if (!isRakutenDomain(urlObj.hostname)) return url;
 
-    urlObj.searchParams.delete("scid");
-    urlObj.searchParams.delete("sc2id");
-    return urlObj.toString();
-  } catch {
-    return url;
-  }
+  const hasScid = urlObj.searchParams.has("scid");
+  const hasSc2id = urlObj.searchParams.has("sc2id");
+  if (!hasScid && !hasSc2id) return url;
+
+  urlObj.searchParams.delete("scid");
+  urlObj.searchParams.delete("sc2id");
+  return urlObj.toString();
+}
+
+function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
+  if (!isAmazonDomain(urlObj.hostname)) return url;
+
+  const hasTag = urlObj.searchParams.has("tag");
+  const hasLinkCode = urlObj.searchParams.has("linkCode");
+  if (!hasTag && !hasLinkCode) return url;
+
+  urlObj.searchParams.delete("tag");
+  urlObj.searchParams.delete("linkCode");
+  return urlObj.toString();
 }
 
 export function purifyResolvedUrl(url: string): string {
-  return purifyResolvedRakutenUrl(url);
+  try {
+    const urlObj = new URL(url);
+    let result = purifyResolvedRakutenUrl(url, urlObj);
+    result = purifyResolvedAmazonUrl(result, new URL(result));
+    return result;
+  } catch {
+    return url;
+  }
 }


### PR DESCRIPTION
## Summary
- `purifyResolvedUrl` に Amazon ドメイン対応を追加し、`tag` / `linkCode` を除去
- チェーン解決（A8.net → Amazon 等）で最終URLがAmazonの場合にもトラッキングパラメータを除去
- テスト3件追加（計6件）

## Test plan
- [x] `pnpm run compile` pass
- [x] `pnpm vitest run src/core/utils/purifyResolvedUrl.spec.ts` 全6テスト pass