### PR TITLE
test: add missing get*Original test coverage

### DIFF
--- a/src/core/accesstrade/getAccessTradeOriginal.spec.ts
+++ b/src/core/accesstrade/getAccessTradeOriginal.spec.ts
@@ -1,0 +1,29 @@
+import { getAccessTradeOriginal } from "./getAccessTradeOriginal";
+
+describe("getAccessTradeOriginal", () => {
+  it("should extract and decode the url parameter", async () => {
+    const url =
+      "https://h.accesstrade.net/sp/cc?rk=ABC123&url=https%3A%2F%2Fexample.com%2Fproduct%3Fid%3D1";
+    const result = await getAccessTradeOriginal(url);
+    expect(result).toBe("https://example.com/product?id=1");
+  });
+
+  it("should follow redirects when url parameter is missing", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com/final" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const url = "https://h.accesstrade.net/sp/cc?rk=ABC123";
+    const result = await getAccessTradeOriginal(url);
+    expect(result).toBe("https://example.com/final");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/core/linka/getLinkAOriginal.spec.ts
+++ b/src/core/linka/getLinkAOriginal.spec.ts
@@ -1,0 +1,34 @@
+import { getLinkAOriginal } from "./getLinkAOriginal";
+
+describe("getLinkAOriginal", () => {
+  it("should follow redirects to the original URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com/product" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const result = await getLinkAOriginal("https://cl.link-ag.net/click/abc123");
+    expect(result).toBe("https://example.com/product");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should return the original URL when no redirect occurs", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const url = "https://cl.link-ag.net/click/abc123";
+    const result = await getLinkAOriginal(url);
+    expect(result).toBe(url);
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/core/linkshare/getLinkShareOriginal.spec.ts
+++ b/src/core/linkshare/getLinkShareOriginal.spec.ts
@@ -1,0 +1,36 @@
+import { getLinkShareOriginal } from "./getLinkShareOriginal";
+
+describe("getLinkShareOriginal", () => {
+  it("should follow redirects to the original URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 301,
+        headers: { location: "https://www.rakuten.co.jp/shop/item123" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const result = await getLinkShareOriginal(
+      "https://click.linksynergy.com/fs-bin/click?id=XXX&offerid=YYY",
+    );
+    expect(result).toBe("https://www.rakuten.co.jp/shop/item123");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should return the original URL when no redirect occurs", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const url = "https://click.linksynergy.com/fs-bin/click?id=XXX";
+    const result = await getLinkShareOriginal(url);
+    expect(result).toBe(url);
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/core/moshimo/getMoshimoOriginal.spec.ts
+++ b/src/core/moshimo/getMoshimoOriginal.spec.ts
@@ -1,0 +1,17 @@
+import { getMoshimoOriginal } from "./getMoshimoOriginal";
+
+describe("getMoshimoOriginal", () => {
+  it("should extract and decode the url parameter", async () => {
+    const url =
+      "https://af.moshimo.com/af/c/click?a_id=1234&p_id=5678&pc_id=90&pl_id=12&url=https%3A%2F%2Fexample.com%2Fproduct%3Fid%3D42";
+    const result = await getMoshimoOriginal(url);
+    expect(result).toBe("https://example.com/product?id=42");
+  });
+
+  it("should throw when url parameter is missing", async () => {
+    const url = "https://af.moshimo.com/af/c/click?a_id=1234&p_id=5678";
+    await expect(getMoshimoOriginal(url)).rejects.toThrow(
+      "No url parameter found in Moshimo affiliate link",
+    );
+  });
+});

--- a/src/core/zucks/getZucksOriginal.spec.ts
+++ b/src/core/zucks/getZucksOriginal.spec.ts
@@ -1,0 +1,32 @@
+import { getZucksOriginal } from "./getZucksOriginal";
+
+describe("getZucksOriginal", () => {
+  it("should follow redirects to the original URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com/app" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const result = await getZucksOriginal("https://get.mobu.jp/redirect/abc123");
+    expect(result).toBe("https://example.com/app");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should return the original URL on fetch error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockRejectedValueOnce(new Error("Network error"));
+
+    const url = "https://get.mobu.jp/redirect/abc123";
+    const result = await getZucksOriginal(url);
+    expect(result).toBe(url);
+
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- 以下5つの URL 解決関数にテストを追加:
  - `getAccessTradeOriginal` (URLパラメータ抽出 + リダイレクト fallback)
  - `getLinkAOriginal` (リダイレクト追跡 + 非リダイレクト時)
  - `getLinkShareOriginal` (リダイレクト追跡 + 非リダイレクト時)
  - `getMoshimoOriginal` (URLパラメータ抽出 + エラーケース)
  - `getZucksOriginal` (リダイレクト追跡 + fetchエラー時)
- 合計10テストケース追加

## Test plan
- [x] `pnpm run compile` pass
- [x] 新規5ファイル全35テスト pass (既存含む)