### PR TITLE
fix: add error handling to A8.net fallback fetch

### DIFF
--- a/src/core/a8net/getA8NetOriginal.ts
+++ b/src/core/a8net/getA8NetOriginal.ts
@@ -74,6 +74,8 @@ async function getA8NetOriginalInternal(url: string): Promise<string> {
     if (resFollow.url && resFollow.url !== url) {
       return resFollow.url;
     }
+  } catch (e) {
+    console.error(`Fallback fetch failed for ${url}`, e);
   } finally {
     clearTimeout(timeoutId2);
   }


### PR DESCRIPTION
## Summary
- `getA8NetOriginalInternal` の2回目の fetch（`redirect: "follow"` フォールバック）に catch ブロックを追加
- ネットワークエラーやタイムアウト時に例外が伝播せず、元のURLを安全に返すように修正

## Test plan
- [x] `pnpm run compile` pass
- [x] `pnpm vitest run src/core/a8net/` 全13テスト pass