### PR TITLE
feat: auto-refresh active tab on settings toggle

### DIFF
--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -32,6 +32,11 @@ function App() {
         ...settings,
         [key]: checked,
       });
+
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tab?.id) {
+        chrome.tabs.reload(tab.id);
+      }
     } catch (error) {
       console.error(`Failed to save setting for ${key}:`, error);
     }


### PR DESCRIPTION
## Summary
- ポップアップで有効/無効を切り替えた後、アクティブタブを自動リロード
- 追加パーミッション不要（`chrome.tabs.query` / `chrome.tabs.reload` は Manifest V3 で権限なしで利用可能）

## Test plan
- [x] `pnpm run compile` pass
- [x] テスト 89/90 pass