### PR TITLE
feat: strip well-known tracking query params from all links

### DIFF
--- a/src/core/utils/purifyResolvedUrl.spec.ts
+++ b/src/core/utils/purifyResolvedUrl.spec.ts
@@ -20,9 +20,7 @@ describe("purifyResolvedUrl", () => {
   it("removes tag and linkCode from amazon domains", () => {
     const input =
       "https://www.amazon.co.jp/dp/B0DJDZRW18?tag=sakurachecker-22&linkCode=ogi&th=1&psc=1";
-    expect(purifyResolvedUrl(input)).toBe(
-      "https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1",
-    );
+    expect(purifyResolvedUrl(input)).toBe("https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1");
   });
 
   it("keeps non-amazon domains untouched for amazon params", () => {
@@ -33,5 +31,16 @@ describe("purifyResolvedUrl", () => {
   it("returns original amazon url when no affiliate params exist", () => {
     const input = "https://www.amazon.co.jp/dp/B0DJDZRW18?th=1&psc=1";
     expect(purifyResolvedUrl(input)).toBe(input);
+  });
+
+  it("strips generic tracking params on any domain", () => {
+    expect(purifyResolvedUrl("https://news.example/article?utm_source=tw&gclid=abc&id=5")).toBe(
+      "https://news.example/article?id=5",
+    );
+  });
+
+  it("strips generic tracking params alongside affiliate params", () => {
+    const input = "https://www.amazon.co.jp/dp/B0?tag=aff-22&utm_source=x&fbclid=y&th=1";
+    expect(purifyResolvedUrl(input)).toBe("https://www.amazon.co.jp/dp/B0?th=1");
   });
 });

--- a/src/core/utils/purifyResolvedUrl.ts
+++ b/src/core/utils/purifyResolvedUrl.ts
@@ -1,3 +1,5 @@
+import { stripTrackingParams } from "./stripTrackingParams";
+
 const rakutenHostSuffix = ".rakuten.co.jp";
 
 function isRakutenDomain(hostname: string): boolean {
@@ -34,8 +36,10 @@ function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
 
 export function purifyResolvedUrl(url: string): string {
   try {
-    const urlObj = new URL(url);
-    let result = purifyResolvedRakutenUrl(url, urlObj);
+    // 1. Domain-agnostic: strip well-known tracking query params (utm_*, gclid,
+    //    fbclid, ...). 2. Domain-specific affiliate tags (Rakuten, Amazon).
+    let result = stripTrackingParams(url);
+    result = purifyResolvedRakutenUrl(result, new URL(result));
     result = purifyResolvedAmazonUrl(result, new URL(result));
     return result;
   } catch {

--- a/src/core/utils/stripTrackingParams.spec.ts
+++ b/src/core/utils/stripTrackingParams.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { stripTrackingParams } from "./stripTrackingParams";
+
+describe("stripTrackingParams", () => {
+  it("removes utm_* params (prefix match)", () => {
+    const input =
+      "https://shop.example/item?utm_source=x&utm_medium=email&utm_campaign=spring&id=5";
+    expect(stripTrackingParams(input)).toBe("https://shop.example/item?id=5");
+  });
+
+  it("removes well-known click-ids (gclid, fbclid, msclkid, ...)", () => {
+    const input = "https://shop.example/p?gclid=a&fbclid=b&msclkid=c&yclid=d&keep=1";
+    expect(stripTrackingParams(input)).toBe("https://shop.example/p?keep=1");
+  });
+
+  it("removes pk_/piwik_/matomo_ analytics params", () => {
+    const input = "https://shop.example/p?pk_campaign=x&matomo_kwd=y&piwik_source=z&ok=1";
+    expect(stripTrackingParams(input)).toBe("https://shop.example/p?ok=1");
+  });
+
+  it("removes the query string entirely when only tracking params remain", () => {
+    expect(stripTrackingParams("https://shop.example/p?utm_source=x&fbclid=y")).toBe(
+      "https://shop.example/p",
+    );
+  });
+
+  it("returns the original string unchanged when there is nothing to strip", () => {
+    const input = "https://shop.example/p?id=5&ref=newsletter";
+    expect(stripTrackingParams(input)).toBe(input);
+  });
+
+  it("does NOT strip functional or affiliate params (tag, scid, q, page)", () => {
+    const input = "https://shop.example/search?q=shoes&page=2&tag=aff-22&scid=abc";
+    expect(stripTrackingParams(input)).toBe(input);
+  });
+
+  it("returns invalid input unchanged", () => {
+    expect(stripTrackingParams("not a url")).toBe("not a url");
+  });
+});

--- a/src/core/utils/stripTrackingParams.ts
+++ b/src/core/utils/stripTrackingParams.ts
@@ -1,0 +1,73 @@
+/**
+ * Well-known, tracking-only query parameters that carry no functional meaning
+ * for the destination page. Removing them is the "query filtering" equivalent of
+ * what Brave / ClearURLs / AdGuard do, and is safe across sites. Affiliate
+ * commission tags (Amazon `tag`, Rakuten `scid`) are intentionally NOT here —
+ * those are handled per-domain in purifyResolvedUrl, since names like `tag` are
+ * too generic to strip globally.
+ */
+const TRACKING_PARAMS = new Set([
+  // Google
+  "gclid",
+  "gclsrc",
+  "dclid",
+  "gbraid",
+  "wbraid",
+  // Meta / Instagram
+  "fbclid",
+  "igshid",
+  "igsh",
+  // Microsoft / Yandex
+  "msclkid",
+  "yclid",
+  "ysclid",
+  // Mailchimp
+  "mc_eid",
+  "mc_cid",
+  // HubSpot
+  "_hsenc",
+  "_hsmi",
+  // X / TikTok / LinkedIn
+  "twclid",
+  "ttclid",
+  "li_fat_id",
+  // misc analytics click-ids
+  "_openstat",
+  "vero_id",
+  "vero_conv",
+  "oly_anon_id",
+  "oly_enc_id",
+  "wickedid",
+  "rb_clickid",
+]);
+
+/** Prefix-matched families (every member is campaign/analytics tracking). */
+const TRACKING_PREFIXES = ["utm_", "pk_", "piwik_", "matomo_"];
+
+function isTrackingParam(name: string): boolean {
+  const n = name.toLowerCase();
+  return TRACKING_PARAMS.has(n) || TRACKING_PREFIXES.some((p) => n.startsWith(p));
+}
+
+/**
+ * Remove well-known tracking query parameters from any URL. Pure and
+ * network-free. Returns the original string unchanged when nothing was removed
+ * (so URLs without tracking params are not needlessly re-serialized).
+ */
+export function stripTrackingParams(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    let changed = false;
+
+    for (const key of [...urlObj.searchParams.keys()]) {
+      if (isTrackingParam(key)) {
+        urlObj.searchParams.delete(key);
+        changed = true;
+      }
+    }
+
+    return changed ? urlObj.toString() : url;
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
## 概要 (A: 汎用トラッキングパラメータ除去)

Brave の query filtering 相当。`utm_*` / `gclid` / `fbclid` / `msclkid` / `yclid` / `mc_eid` / `_hsenc` / `ttclid` … と `pk_`/`piwik_`/`matomo_` プレフィックスを**全リンクから除去**します。

- 純粋関数 `stripTrackingParams`（ネットワーク非接触）を `purifyResolvedUrl` に統合 → eager 解決される全リンクに適用。
- **追加権限なし**。
- アフィリエイト成果タグ（Amazon `tag`／楽天 `scid`）は従来どおりドメイン別処理（`tag` 等は汎用除去には危険なため）。
- 機能パラメータ（`q`/`page`/`id` 等）は除去しない。

## テスト
- `pnpm test`：135 pass / 1 skip。`pnpm build` / `build:firefox`：OK。
- `stripTrackingParams.spec` と `purifyResolvedUrl.spec` に正・負ケース追加。
