### PR TITLE
feat: remove affiliate-network cookies to break cookie-based attribution

### DIFF
--- a/src/core/affiliateCookieDomains.spec.ts
+++ b/src/core/affiliateCookieDomains.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isAffiliateCookieDomain } from "./affiliateCookieDomains";
+
+describe("isAffiliateCookieDomain", () => {
+  it("matches affiliate-network domains and their subdomains", () => {
+    for (const d of [
+      "a8.net",
+      ".a8.net",
+      "px.a8.net",
+      "valuecommerce.com",
+      "ck.jp.ap.valuecommerce.com",
+      "accesstrade.net",
+      "moshimo.com",
+      "afl.rakuten.co.jp",
+      "hb.afl.rakuten.co.jp",
+      ".afl.rakuten.co.jp",
+      "linksynergy.com",
+      "click.linksynergy.com",
+    ]) {
+      expect(isAffiliateCookieDomain(d)).toBe(true);
+    }
+  });
+
+  it("does NOT match merchant / functional domains", () => {
+    for (const d of [
+      "rakuten.co.jp", // shopping site — must be preserved
+      "www.rakuten.co.jp",
+      ".rakuten.co.jp",
+      "item.rakuten.co.jp",
+      "amazon.co.jp",
+      "www.amazon.co.jp",
+      "example.com",
+      "google.com",
+      "not-a8.net", // not a subdomain of a8.net
+      "fakea8.net",
+    ]) {
+      expect(isAffiliateCookieDomain(d)).toBe(false);
+    }
+  });
+});

--- a/src/core/affiliateCookieDomains.ts
+++ b/src/core/affiliateCookieDomains.ts
@@ -1,0 +1,45 @@
+/**
+ * Domains belonging to affiliate NETWORKS (not merchants). Cookies set on these
+ * are used purely to attribute affiliate commissions, so deleting them is safe —
+ * it does not touch a merchant's functional cookies.
+ *
+ * IMPORTANT: entries must be affiliate-only infrastructure. Rakuten is listed as
+ * `afl.rakuten.co.jp` (the affiliate subdomain) and NOT `rakuten.co.jp`, so we
+ * never delete cookies for the Rakuten shopping site itself. Likewise we never
+ * list merchant domains (amazon.co.jp, etc.).
+ */
+export const AFFILIATE_COOKIE_DOMAINS = [
+  // Japan
+  "a8.net",
+  "valuecommerce.com",
+  "valuecommerce.ne.jp",
+  "accesstrade.net",
+  "moshimo.com",
+  "afl.rakuten.co.jp", // affiliate subdomain ONLY — never rakuten.co.jp
+  "link-a.net",
+  "link-ag.net",
+  "afi-b.com",
+  "felmat.net",
+  // Global
+  "linksynergy.com", // Rakuten Advertising / LinkShare
+  "dpbolvw.net", // Commission Junction
+  "anrdoezrs.net",
+  "tkqlhce.com",
+  "kqzyfj.com",
+  "jdoqocy.com",
+  "awin1.com", // Awin
+  "prf.hn", // Impact / Partnerize
+  "shareasale.com",
+  "skimresources.com", // Skimlinks
+  "go.redirectingat.com",
+] as const;
+
+/**
+ * True if a cookie's domain belongs to an affiliate network (exact match or a
+ * subdomain of a listed domain). Parent/sibling domains do NOT match, so e.g.
+ * `rakuten.co.jp` is never matched by `afl.rakuten.co.jp`.
+ */
+export function isAffiliateCookieDomain(domain: string): boolean {
+  const d = domain.replace(/^\./, "").toLowerCase();
+  return AFFILIATE_COOKIE_DOMAINS.some((t) => d === t || d.endsWith("." + t));
+}

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,7 +1,30 @@
+import { isAffiliateCookieDomain } from "@/core/affiliateCookieDomains";
+import { createCookieCleaner } from "@/services/cookieCleaner";
+import { SETTINGS_KEYS, loadSettings } from "@/services/settings";
+
 export default defineBackground(() => {
-  // Link resolution now runs inline in the content script (offline-only, pure),
-  // so the background no longer resolves links or makes any network request.
   console.log("Goodbye Affiliate Link: Background script loaded!", {
     id: browser.runtime.id,
+  });
+
+  const cleaner = createCookieCleaner(chrome.cookies);
+
+  // Registered synchronously at the top level so the (ephemeral MV3) service
+  // worker reliably wakes on cookie changes. The cheap domain check runs first
+  // so we only load settings for affiliate-network cookies, not every cookie.
+  chrome.cookies.onChanged.addListener(async (change) => {
+    if (change.removed || !isAffiliateCookieDomain(change.cookie.domain)) return;
+    const { enabled } = await loadSettings();
+    if (enabled !== false) cleaner.handleChange(change);
+  });
+
+  // Sweep any pre-existing affiliate cookies on startup and whenever enabled.
+  loadSettings().then(({ enabled }) => {
+    if (enabled !== false) cleaner.clearAll();
+  });
+  chrome.storage.onChanged.addListener((changes) => {
+    if (changes[SETTINGS_KEYS.ENABLED]?.newValue === true) {
+      cleaner.clearAll();
+    }
   });
 });

--- a/src/services/cookieCleaner.spec.ts
+++ b/src/services/cookieCleaner.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCookieCleaner } from "./cookieCleaner";
+
+function makeCookie(overrides: Partial<chrome.cookies.Cookie>): chrome.cookies.Cookie {
+  return {
+    name: "x",
+    value: "1",
+    domain: ".a8.net",
+    path: "/",
+    secure: true,
+    httpOnly: false,
+    sameSite: "no_restriction",
+    session: false,
+    hostOnly: false,
+    storeId: "0",
+    ...overrides,
+  } as chrome.cookies.Cookie;
+}
+
+let cookies: { getAll: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  cookies = {
+    getAll: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue({}),
+  };
+});
+
+describe("createCookieCleaner", () => {
+  it("removes a newly-set affiliate cookie with the right url", () => {
+    const cleaner = createCookieCleaner(cookies as unknown as typeof chrome.cookies);
+    cleaner.handleChange({
+      removed: false,
+      cause: "explicit",
+      cookie: makeCookie({ name: "uid", domain: ".a8.net", path: "/", secure: true }),
+    } as chrome.cookies.CookieChangeInfo);
+
+    expect(cookies.remove).toHaveBeenCalledWith({
+      url: "https://a8.net/",
+      name: "uid",
+      storeId: "0",
+    });
+  });
+
+  it("ignores cookie deletions (does not loop on its own removals)", () => {
+    const cleaner = createCookieCleaner(cookies as unknown as typeof chrome.cookies);
+    cleaner.handleChange({
+      removed: true,
+      cause: "explicit",
+      cookie: makeCookie({ domain: ".a8.net" }),
+    } as chrome.cookies.CookieChangeInfo);
+
+    expect(cookies.remove).not.toHaveBeenCalled();
+  });
+
+  it("ignores cookies on non-affiliate (merchant) domains", () => {
+    const cleaner = createCookieCleaner(cookies as unknown as typeof chrome.cookies);
+    cleaner.handleChange({
+      removed: false,
+      cause: "explicit",
+      cookie: makeCookie({ domain: ".rakuten.co.jp" }),
+    } as chrome.cookies.CookieChangeInfo);
+
+    expect(cookies.remove).not.toHaveBeenCalled();
+  });
+
+  it("clearAll sweeps existing affiliate cookies via getAll + remove", async () => {
+    cookies.getAll.mockImplementation(async ({ domain }: { domain: string }) =>
+      domain === "a8.net" ? [makeCookie({ name: "uid", domain: ".a8.net" })] : [],
+    );
+
+    const cleaner = createCookieCleaner(cookies as unknown as typeof chrome.cookies);
+    await cleaner.clearAll();
+
+    expect(cookies.remove).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://a8.net/", name: "uid" }),
+    );
+  });
+
+  it("builds an http url for non-secure cookies", () => {
+    const cleaner = createCookieCleaner(cookies as unknown as typeof chrome.cookies);
+    const url = cleaner.urlForCookie(
+      makeCookie({ domain: "px.a8.net", path: "/svt", secure: false }),
+    );
+    expect(url).toBe("http://px.a8.net/svt");
+  });
+});

--- a/src/services/cookieCleaner.ts
+++ b/src/services/cookieCleaner.ts
@@ -1,0 +1,53 @@
+import { AFFILIATE_COOKIE_DOMAINS, isAffiliateCookieDomain } from "@/core/affiliateCookieDomains";
+
+type CookiesApi = typeof chrome.cookies;
+
+/**
+ * Deletes affiliate-network cookies so a later conversion cannot be attributed
+ * via a last-click cookie. Only touches domains in AFFILIATE_COOKIE_DOMAINS
+ * (network infrastructure), never a merchant's functional cookies. It cannot
+ * defeat server-side click-id attribution — that is a known, documented limit.
+ *
+ * Pure wiring around the injected `cookies` API so it is unit-testable.
+ */
+export function createCookieCleaner(cookies: CookiesApi) {
+  function urlForCookie(cookie: chrome.cookies.Cookie): string {
+    const domain = cookie.domain.replace(/^\./, "");
+    const scheme = cookie.secure ? "https" : "http";
+    return `${scheme}://${domain}${cookie.path || "/"}`;
+  }
+
+  function removeCookie(cookie: chrome.cookies.Cookie): void {
+    void cookies.remove({
+      url: urlForCookie(cookie),
+      name: cookie.name,
+      storeId: cookie.storeId,
+    });
+  }
+
+  /** React to a single cookie change (the onChanged event payload). */
+  function handleChange(change: chrome.cookies.CookieChangeInfo): void {
+    if (change.removed) return; // ignore deletions (including our own)
+    if (isAffiliateCookieDomain(change.cookie.domain)) {
+      removeCookie(change.cookie);
+    }
+  }
+
+  /** Sweep any pre-existing affiliate cookies (on startup / on enable). */
+  async function clearAll(): Promise<void> {
+    for (const domain of AFFILIATE_COOKIE_DOMAINS) {
+      try {
+        const found = await cookies.getAll({ domain });
+        for (const cookie of found) {
+          if (isAffiliateCookieDomain(cookie.domain)) {
+            removeCookie(cookie);
+          }
+        }
+      } catch {
+        // ignore: domain may have no cookies, or a transient API error
+      }
+    }
+  }
+
+  return { handleChange, clearAll, removeCookie, urlForCookie };
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     name: "Goodbye Affiliate Link",
     description: "ページ中のアフィリエイトリンクを元々のURLに戻すChrome拡張機能です。",
     version: "1.0.0",
-    permissions: ["storage"],
+    permissions: ["storage", "cookies"],
     host_permissions: ["*://*/*"],
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
## 概要 (B: アフィリエイト cookie の除去)

不透明型リンク（A8.net 等）をユーザーが実際にクリックしても、**最終クリック cookie による成果計上**を無効化します。`chrome.cookies` で**アフィリエイトネットワークのドメインに設定された cookie のみ**を削除します（継続的な `onChanged` 監視＋起動/有効化時の一括スイープ）。

- 対象は a8.net / valuecommerce / accesstrade / moshimo / `afl.rakuten.co.jp` / linksynergy / CJ / Awin / Impact / ShareASale / Skimlinks 等の**ネットワーク基盤ドメインのみ**。
- **店舗/機能 cookie（`rakuten.co.jp`・`amazon.co.jp` 等）は絶対に触りません**（`afl.rakuten.co.jp` は対象だが `rakuten.co.jp` は対象外、をテストで保証）。
- `enabled` 設定でON/OFF。`cookies` 権限を追加。
- MV3 SW の揮発性に対応し、`onChanged` リスナはトップレベルで同期登録。

## 限界（正直に）
サーバー側 click-id 方式（例：A8 のセッショントラッキング）は cookie 削除では消せません。これは文書化済みの原理的限界です。

## テスト
- `pnpm test`：142 pass / 1 skip。`build`/`build:firefox`：OK。manifest 権限 = `["storage","cookies"]`。
- ドメイン判定（店舗ドメイン非マッチ）と cleaner ロジック（onChanged/clearAll/URL生成）を単体テスト。
