### PR TITLE
feat: opt-in cookieless resolution of opaque affiliate links

### DIFF
--- a/src/core/utils/resolveRedirects.spec.ts
+++ b/src/core/utils/resolveRedirects.spec.ts
@@ -84,4 +84,19 @@ describe("resolveRedirects", () => {
     const result = await resolveRedirects("http://example.com/error");
     expect(result).toBe("http://example.com/error");
   });
+
+  it("fetches cookielessly (credentials: omit)", async () => {
+    const mockFetch = global.fetch as any;
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      url: "http://example.com/x",
+      headers: { get: () => null },
+    });
+
+    await resolveRedirects("http://example.com/x");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://example.com/x",
+      expect.objectContaining({ credentials: "omit" }),
+    );
+  });
 });

--- a/src/core/utils/resolveRedirects.ts
+++ b/src/core/utils/resolveRedirects.ts
@@ -17,6 +17,7 @@ export async function resolveRedirects(
     try {
       res = await fetch(url, {
         redirect: "manual",
+        credentials: "omit", // cookieless: never send/store affiliate cookies
         signal: controller.signal,
       });
     } catch (e: unknown) {

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,3 +1,8 @@
+import {
+  ResolveAffiliateLinksMessage,
+  ResolveAffiliateLinksResponse,
+  resolveLinksWithChunks,
+} from "@/core";
 import { isAffiliateCookieDomain } from "@/core/affiliateCookieDomains";
 import { createCookieCleaner } from "@/services/cookieCleaner";
 import { SETTINGS_KEYS, loadSettings } from "@/services/settings";
@@ -8,6 +13,37 @@ export default defineBackground(() => {
   });
 
   const cleaner = createCookieCleaner(chrome.cookies);
+
+  // Opt-in (resolveOpaque): resolve opaque-token affiliate links by following
+  // their redirect COOKIELESSLY (resolveRedirects now sends credentials:"omit"),
+  // so the user lands directly on the clean destination. Disabled by default,
+  // so by default the background makes no network request at all.
+  chrome.runtime.onMessage.addListener(
+    (
+      message: ResolveAffiliateLinksMessage,
+      _sender,
+      sendResponse: (response: ResolveAffiliateLinksResponse) => void,
+    ) => {
+      if (message.type !== "RESOLVE_AFFILIATE_LINKS") return;
+
+      loadSettings()
+        .then(({ enabled, resolveOpaque }) => {
+          if (enabled === false || !resolveOpaque) {
+            sendResponse({ resolvedLinks: {} });
+            return;
+          }
+          return resolveLinksWithChunks(message.links).then((resolvedLinks) =>
+            sendResponse({ resolvedLinks }),
+          );
+        })
+        .catch((error) => {
+          console.error("Goodbye Affiliate Link: opaque resolve failed", error);
+          sendResponse({ resolvedLinks: {} });
+        });
+
+      return true; // keep the message channel open for the async response
+    },
+  );
 
   // Registered synchronously at the top level so the (ephemeral MV3) service
   // worker reliably wakes on cookie changes. The cheap domain check runs first

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -1,9 +1,12 @@
 import { SETTINGS_KEYS, loadSettings } from "@/services/settings";
 import { createLinkRewriter } from "@/services/rewriteLinks";
+import { createOpaqueResolver } from "@/services/opaqueResolver";
 
 // Pure, synchronous, network-free rewriting — resolving every link on the page
 // triggers no affiliate clicks/conversions.
 const { rewriteAnchor, rewriteWithin } = createLinkRewriter();
+// Opt-in: cookieless on-hover resolution of opaque-token links (network).
+const opaqueResolver = createOpaqueResolver();
 let observer: MutationObserver | null = null;
 
 function observeAnchors() {
@@ -47,10 +50,11 @@ function stopProcessing() {
 }
 
 async function init() {
-  const { enabled } = await loadSettings();
+  const { enabled, resolveOpaque } = await loadSettings();
 
   if (enabled !== false) {
     startProcessing();
+    if (resolveOpaque) opaqueResolver.start();
   }
 
   chrome.storage.onChanged.addListener((changes) => {
@@ -60,6 +64,16 @@ async function init() {
         startProcessing();
       } else {
         stopProcessing();
+        opaqueResolver.stop();
+      }
+    }
+
+    if (changes[SETTINGS_KEYS.RESOLVE_OPAQUE]) {
+      const on = changes[SETTINGS_KEYS.RESOLVE_OPAQUE].newValue === true;
+      if (on) {
+        opaqueResolver.start();
+      } else {
+        opaqueResolver.stop();
       }
     }
   });

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -60,6 +60,12 @@ function App() {
               defaultChecked={settings.enabled}
               onChange={(checked) => handleToggleChange(SETTINGS_KEYS.ENABLED, checked)}
             />
+            <ToggleSwitch
+              id="resolveOpaque"
+              label="不透明リンクもクリック時に解決（通信あり）"
+              defaultChecked={settings.resolveOpaque}
+              onChange={(checked) => handleToggleChange(SETTINGS_KEYS.RESOLVE_OPAQUE, checked)}
+            />
           </div>
         )}
 

--- a/src/services/opaqueResolver.spec.ts
+++ b/src/services/opaqueResolver.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createOpaqueResolver } from "./opaqueResolver";
+
+let sendMessage: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  sendMessage = vi.fn(
+    (msg: { links: string[] }, cb: (r: { resolvedLinks: Record<string, string> }) => void) => {
+      cb({ resolvedLinks: { [msg.links[0]]: "https://shop.example/clean" } });
+    },
+  );
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { lastError: undefined, sendMessage },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  vi.restoreAllMocks();
+});
+
+function fireIntent(el: Element) {
+  el.dispatchEvent(new Event("pointerover", { bubbles: true }));
+}
+
+describe("createOpaqueResolver", () => {
+  it("resolves an anchor on hover and rewrites its href", () => {
+    document.body.innerHTML = `<a id="x" href="https://px.a8.net/svt/ejp?a8mat=ABC">go</a>`;
+    const resolver = createOpaqueResolver();
+    resolver.start();
+
+    const a = document.getElementById("x") as HTMLAnchorElement;
+    fireIntent(a);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(a.href).toBe("https://shop.example/clean");
+    resolver.stop();
+  });
+
+  it("does nothing after stop()", () => {
+    document.body.innerHTML = `<a id="y" href="https://px.a8.net/svt/ejp?a8mat=XYZ">go</a>`;
+    const resolver = createOpaqueResolver();
+    resolver.start();
+    resolver.stop();
+
+    fireIntent(document.getElementById("y") as HTMLAnchorElement);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not re-send for an already-resolved link", () => {
+    document.body.innerHTML = `<a id="z" href="https://px.a8.net/svt/ejp?a8mat=Q">go</a>`;
+    const resolver = createOpaqueResolver();
+    resolver.start();
+
+    const a = document.getElementById("z") as HTMLAnchorElement;
+    fireIntent(a); // resolves a8mat -> clean
+    fireIntent(a); // href is now clean (cached no-op)
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    resolver.stop();
+  });
+});

--- a/src/services/opaqueResolver.ts
+++ b/src/services/opaqueResolver.ts
@@ -1,0 +1,78 @@
+import type { ResolveAffiliateLinksMessage, ResolveAffiliateLinksResponse } from "@/core";
+
+/**
+ * Opt-in resolver for opaque-token affiliate links (destination only known
+ * server-side, e.g. A8.net a8mat=). On user intent (hover/focus), it asks the
+ * background to resolve the link COOKIELESSLY and rewrites the anchor to the
+ * clean destination — so the click lands directly on the merchant with no
+ * cookie/click-id attribution (only an IP-residual from the one lookup).
+ *
+ * Resolution must go through the background: cross-origin fetches from a content
+ * script are subject to page CORS, whereas the background has host permissions.
+ */
+export function createOpaqueResolver() {
+  const resolvedCache = new Map<string, string>();
+  const inFlight = new Set<string>();
+  let listening = false;
+
+  const INTENT_EVENTS = ["pointerover", "focusin", "touchstart", "mousedown"] as const;
+
+  function applyResolved(anchor: HTMLAnchorElement, originalHref: string, resolved: string) {
+    if (resolved !== originalHref && anchor.href === originalHref) {
+      anchor.href = resolved;
+    }
+  }
+
+  function resolveAnchor(anchor: HTMLAnchorElement) {
+    const href = anchor.href;
+    if (!href) return;
+
+    const cached = resolvedCache.get(href);
+    if (cached !== undefined) {
+      applyResolved(anchor, href, cached);
+      return;
+    }
+    if (inFlight.has(href)) return;
+    inFlight.add(href);
+
+    chrome.runtime.sendMessage<ResolveAffiliateLinksMessage, ResolveAffiliateLinksResponse>(
+      { type: "RESOLVE_AFFILIATE_LINKS", links: [href] },
+      (response) => {
+        inFlight.delete(href);
+        if (chrome.runtime.lastError || !response) return;
+
+        const resolved = response.resolvedLinks[href] ?? href;
+        resolvedCache.set(href, resolved);
+        if (resolved !== href) resolvedCache.set(resolved, resolved);
+        applyResolved(anchor, href, resolved);
+      },
+    );
+  }
+
+  function handleIntent(event: Event) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const anchor = target.closest("a");
+    if (anchor instanceof HTMLAnchorElement) {
+      resolveAnchor(anchor);
+    }
+  }
+
+  function start() {
+    if (listening) return;
+    listening = true;
+    for (const type of INTENT_EVENTS) {
+      document.addEventListener(type, handleIntent, { capture: true, passive: true });
+    }
+  }
+
+  function stop() {
+    if (!listening) return;
+    listening = false;
+    for (const type of INTENT_EVENTS) {
+      document.removeEventListener(type, handleIntent, { capture: true });
+    }
+  }
+
+  return { start, stop };
+}

--- a/src/services/settings.spec.ts
+++ b/src/services/settings.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { loadSettings } from "./settings";
+
+type Store = Record<string, unknown>;
+
+function mockChromeStorage(store: Store) {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      local: {
+        get: (_keys: string[], cb: (result: Store) => void) => cb(store),
+      },
+    },
+  };
+}
+
+beforeEach(() => mockChromeStorage({}));
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  vi.restoreAllMocks();
+});
+
+describe("loadSettings", () => {
+  it("returns defaults when nothing is stored (enabled on, resolveOpaque off)", async () => {
+    expect(await loadSettings()).toEqual({ enabled: true, resolveOpaque: false });
+  });
+
+  it("respects stored values", async () => {
+    mockChromeStorage({ enabled: false, resolveOpaque: true });
+    expect(await loadSettings()).toEqual({ enabled: false, resolveOpaque: true });
+  });
+
+  it("coerces non-true values to false", async () => {
+    mockChromeStorage({ enabled: "yes", resolveOpaque: 1 });
+    expect(await loadSettings()).toEqual({ enabled: false, resolveOpaque: false });
+  });
+});

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,21 +1,28 @@
 // Define keys for the settings
 export const SETTINGS_KEYS = {
   ENABLED: "enabled",
+  // Opt-in: also resolve opaque-token affiliate links (whose destination only
+  // exists server-side) by contacting the redirect endpoint COOKIELESSLY on
+  // hover. Off by default because it makes one network request to the tracker.
+  RESOLVE_OPAQUE: "resolveOpaque",
 } as const;
 
 // Define the Settings type
 export interface Settings {
   [SETTINGS_KEYS.ENABLED]: boolean;
+  [SETTINGS_KEYS.RESOLVE_OPAQUE]: boolean;
 }
 
 // Alternative interface definition to avoid computed property issues
 export type SettingsType = {
   enabled: boolean;
+  resolveOpaque: boolean;
 };
 
 // Default settings
 export const DEFAULT_SETTINGS: SettingsType = {
   enabled: true,
+  resolveOpaque: false,
 };
 
 // Load settings from chrome.storage.local
@@ -27,6 +34,9 @@ export async function loadSettings(): Promise<SettingsType> {
       // Only override default values if they exist in storage
       if (result[SETTINGS_KEYS.ENABLED] !== undefined) {
         settings.enabled = result[SETTINGS_KEYS.ENABLED] === true;
+      }
+      if (result[SETTINGS_KEYS.RESOLVE_OPAQUE] !== undefined) {
+        settings.resolveOpaque = result[SETTINGS_KEYS.RESOLVE_OPAQUE] === true;
       }
 
       resolve(settings);


### PR DESCRIPTION
## 概要 (C: 不透明リンクの opt-in cookieless 解決)

不透明トークン型（A8.net `a8mat=` / Zucks / Link-A 等：宛先がサーバー応答にしか無い）を、**任意設定（既定OFF）**で解決します。ONのとき、コンテンツスクリプトが **hover 時**に背景へ依頼し、背景がリダイレクトを **cookie 無し**（`credentials:"omit"`）で辿って最終URLを取得→アンカーをクリーンURLへ書き換えます。ユーザーは店舗へ直接着地し、**cookie/click-id による成果計上は発生しません**（1回のlookup分のIP残留のみ）。

- 新設定 `resolveOpaque`（既定 **false**）＋ ポップアップにトグル追加。
- 既定では従来どおり **strict offline-only（通信ゼロ）**。背景が通信するのは「opt-in かつ hover した時」だけ。
- `resolveRedirects` を cookieless 化（`credentials:"omit"`）。cross-origin fetch は背景経由（content script は CORS 制約のため）。
- 既存の cookie 削除（B）・トラッキング除去（A）と共存。

## 限界（正直に）
サーバー側 click-id（A8 のセッショントラッキング等）は接触時にサーバーへ記録されるため、IP残留は残ります（＝完全除去ではなく「決定的な結合キーを潰す」もの）。だから既定OFFの明示オプトインにしています。

## テスト
- `pnpm test`：149 pass / 1 skip（`opaqueResolver` の hover→解決→書換、`settings` 既定、`resolveRedirects` の cookieless を追加）。
- `build`/`build:firefox` OK。content バンドルにプロバイダ/通信コードは混入せず（`import type` 確認、content.js 7.97kB）。
