### PR TITLE
feat: broaden affiliate link removal coverage

### DIFF
--- a/src/core/affiliateCookieDomains.spec.ts
+++ b/src/core/affiliateCookieDomains.spec.ts
@@ -16,6 +16,19 @@ describe("isAffiliateCookieDomain", () => {
       ".afl.rakuten.co.jp",
       "linksynergy.com",
       "click.linksynergy.com",
+      "j-a-net.jp",
+      "click.j-a-net.jp",
+      "px.tcs-asp.net",
+      "www.rentracks.jp",
+      "infotop.jp",
+      "get.mobu.jp",
+      "ad.smart-c.jp",
+      "pollen.sjv.io",
+      "brand.pxf.io",
+      "hop.clickbank.net",
+      "redirect.viglink.com",
+      "clk.tradedoubler.com",
+      "track.webgains.com",
     ]) {
       expect(isAffiliateCookieDomain(d)).toBe(true);
     }

--- a/src/core/affiliateCookieDomains.ts
+++ b/src/core/affiliateCookieDomains.ts
@@ -20,6 +20,12 @@ export const AFFILIATE_COOKIE_DOMAINS = [
   "link-ag.net",
   "afi-b.com",
   "felmat.net",
+  "j-a-net.jp", // JANet
+  "tcs-asp.net", // TCSアフィリエイト
+  "rentracks.jp", // レントラックス
+  "infotop.jp",
+  "mobu.jp", // Zucks (get.mobu.jp redirect)
+  "smart-c.jp", // Smart-C (アドウェイズ)
   // Global
   "linksynergy.com", // Rakuten Advertising / LinkShare
   "dpbolvw.net", // Commission Junction
@@ -29,9 +35,17 @@ export const AFFILIATE_COOKIE_DOMAINS = [
   "jdoqocy.com",
   "awin1.com", // Awin
   "prf.hn", // Impact / Partnerize
+  "sjv.io", // Impact tracking domains (per-merchant subdomains)
+  "pxf.io",
+  "evyy.net",
+  "7eer.net",
   "shareasale.com",
   "skimresources.com", // Skimlinks
   "go.redirectingat.com",
+  "viglink.com", // VigLink / Sovrn
+  "clickbank.net", // ClickBank (hop.clickbank.net)
+  "tradedoubler.com",
+  "webgains.com",
 ] as const;
 
 /**

--- a/src/core/affiliateMap.ts
+++ b/src/core/affiliateMap.ts
@@ -3,6 +3,7 @@ import * as accesstrade from "./accesstrade";
 import * as amazon from "./amazon";
 import * as linka from "./linka";
 import * as moshimo from "./moshimo";
+import * as opaque from "./opaque";
 import * as rakuten from "./rakuten";
 import * as valuecommerce from "./valuecommerce";
 import * as zucks from "./zucks";
@@ -46,5 +47,11 @@ export const affiliateMap: AffiliateMap = {
   zucks: {
     isAffiliateLink: zucks.isZucks,
     getOriginalLink: zucks.getZucksOriginal,
+  },
+  // 固有プロバイダに該当しない既知の不透明リダイレクト群 (afb/felmat/JANet/...)。
+  // Object.entries の挿入順で最後に評価されるよう、末尾に置く。
+  opaque: {
+    isAffiliateLink: opaque.isOpaqueRedirect,
+    getOriginalLink: opaque.getOpaqueRedirectOriginal,
   },
 };

--- a/src/core/amazon/getAmazonOriginal.spec.ts
+++ b/src/core/amazon/getAmazonOriginal.spec.ts
@@ -21,6 +21,37 @@ describe("getAmazonOriginal", () => {
     expect(result).toBe("https://www.amazon.co.jp/gp/product/B08JLZV7G1?ref=nosim");
   });
 
+  it("should remove the full associate param set (linkId, creative, camp, ascsubtag...)", async () => {
+    const url =
+      "https://www.amazon.co.jp/dp/B0DJDZRW18?tag=x-22&linkId=abc&creative=123&creativeASIN=B0&camp=247&ascsubtag=sub&th=1";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.co.jp/dp/B0DJDZRW18?th=1");
+  });
+
+  it("should strip the trailing /ref= attribution path segment", async () => {
+    const url = "https://www.amazon.co.jp/dp/B08JLZV7G1/ref=nosim?tag=example-22";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.co.jp/dp/B08JLZV7G1");
+  });
+
+  it("should work on non-JP amazon domains", async () => {
+    const url = "https://www.amazon.com/dp/B08JLZV7G1/ref=as_li_ss_tl?tag=example-20&linkCode=ll1";
+    const result = await getAmazonOriginal(url);
+    expect(result).toBe("https://www.amazon.com/dp/B08JLZV7G1");
+  });
+
+  it("should resolve amzn.asia short links via redirect", async () => {
+    const redirectTarget = "https://www.amazon.co.jp/dp/B08JLZV7G1/ref=cm_sw_r_as?tag=test-22";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, {
+        status: 301,
+        headers: { location: redirectTarget },
+      }),
+    );
+    const result = await getAmazonOriginal("https://amzn.asia/d/abcDEF1");
+    expect(result).toBe("https://www.amazon.co.jp/dp/B08JLZV7G1");
+  });
+
   it("should resolve amzn.to short links via redirect", async () => {
     const redirectTarget = "https://www.amazon.co.jp/dp/B08JLZV7G1?tag=test-22&linkCode=ogi";
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(

--- a/src/core/amazon/getAmazonOriginal.ts
+++ b/src/core/amazon/getAmazonOriginal.ts
@@ -1,18 +1,17 @@
 import { resolveRedirects } from "../utils";
+import { purifyResolvedUrl } from "../utils/purifyResolvedUrl";
 
 /**
  * Get the original URL from an Amazon affiliate link
- * @param url https://www.amazon.co.jp/dp/ASIN/ref=nosim?tag=あなたのID-22 or https://amzn.to/XXXXX
+ * @param url https://www.amazon.co.jp/dp/ASIN/ref=nosim?tag=あなたのID-22,
+ *            https://amzn.to/XXXXX or https://amzn.asia/d/XXXXX
  */
 export async function getAmazonOriginal(url: string): Promise<string> {
-  // Handle amzn.to short links
-  if (url.startsWith("https://amzn.to/")) {
+  // Short links (amzn.to / amzn.asia) only reveal the destination via redirect
+  if (/^https?:\/\/amzn\.(?:to|asia)\//.test(url)) {
     url = await resolveRedirects(url);
   }
 
-  // Remove affiliate parameters
-  const urlObj = new URL(url);
-  urlObj.searchParams.delete("tag");
-  urlObj.searchParams.delete("linkCode");
-  return urlObj.toString();
+  // Strip the associate tag & friends (full list lives in purifyResolvedUrl)
+  return purifyResolvedUrl(url);
 }

--- a/src/core/amazon/isAmazon.spec.ts
+++ b/src/core/amazon/isAmazon.spec.ts
@@ -4,8 +4,15 @@ describe("isAmazon", () => {
   it.each([
     ["https://www.amazon.co.jp/dp/B08JLZV7G1/ref=nosim?tag=example-22", true],
     ["https://www.amazon.co.jp/gp/product/B08JLZV7G1?tag=example-22", true],
+    ["https://www.amazon.co.jp/dp/B08JLZV7G1?tag=example-22&th=1", true],
+    ["https://www.amazon.com/dp/B08JLZV7G1?tag=example-20", true],
+    ["https://www.amazon.de/dp/B08JLZV7G1?tag=example-21", true],
+    ["https://www.amazon.com.au/dp/B08JLZV7G1?tag=example-22", true],
     ["https://amzn.to/3abcDEF", true],
+    ["https://amzn.asia/d/abcDEF1", true],
     ["https://www.amazon.co.jp/dp/B08JLZV7G1/", false],
+    ["https://www.amazon.co.jp/s?k=keyboard&tag=", false],
+    ["https://example.com/path?tag=example-22", false],
     ["https://amzn.jp/B08JLZV7G1", false],
   ])("%s", (url, expected) => {
     expect(isAmazon(url)).toBe(expected);

--- a/src/core/amazon/isAmazon.ts
+++ b/src/core/amazon/isAmazon.ts
@@ -1,9 +1,18 @@
+/** Every Amazon retail TLD, matching purifyResolvedUrl's list. */
+const amazonHost =
+  "amazon\\.(?:com|co\\.jp|co\\.uk|de|fr|it|es|ca|cn|in|nl|se|pl|sg|ae|sa|eg|com\\.au|com\\.br|com\\.mx|com\\.tr|com\\.be)";
+
+// Associate tags end in a numeric locale suffix (-22 JP, -20 US, -21 UK/DE, ...).
+const amazonRegex = new RegExp(
+  `^https?:\\/\\/(?:[\\w-]+\\.)?${amazonHost}\\/.*[?&]tag=[\\w.-]+-\\d{2}(?:[&#]|$)` +
+    `|^https?:\\/\\/amzn\\.(?:to|asia)\\/[A-Za-z0-9]`,
+);
+
 /**
  * Check if the url is Amazon affiliate link
- * @param url https://www.amazon.co.jp/dp/ASIN/ref=nosim?tag=あなたのID-22 or https://amzn.to/XXXXX
+ * @param url https://www.amazon.co.jp/dp/ASIN/ref=nosim?tag=あなたのID-22,
+ *            https://amzn.to/XXXXX or https://amzn.asia/d/XXXXX
  */
 export function isAmazon(url: string): boolean {
-  const amazonRegex =
-    /^https?:\/\/(?:www\.)?amazon\.co\.jp\/.*[?&]tag=[A-Za-z0-9_-]+-22|^https?:\/\/amzn\.to\/[A-Za-z0-9]+/;
   return amazonRegex.test(url);
 }

--- a/src/core/opaque/getOpaqueRedirectOriginal.spec.ts
+++ b/src/core/opaque/getOpaqueRedirectOriginal.spec.ts
@@ -1,0 +1,30 @@
+import { getOpaqueRedirectOriginal } from "./getOpaqueRedirectOriginal";
+
+describe("getOpaqueRedirectOriginal", () => {
+  it("should follow redirects to the original URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://shop.example/item/42" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await getOpaqueRedirectOriginal("https://t.afi-b.com/visit.php?guid=ON&a=A1");
+    expect(result).toBe("https://shop.example/item/42");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("should return the original URL on fetch error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockRejectedValueOnce(new Error("Network error"));
+
+    const url = "https://t.felmat.net/fmcl?ak=B1234.5678";
+    const result = await getOpaqueRedirectOriginal(url);
+    expect(result).toBe(url);
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/core/opaque/getOpaqueRedirectOriginal.ts
+++ b/src/core/opaque/getOpaqueRedirectOriginal.ts
@@ -1,0 +1,11 @@
+import { resolveRedirects } from "../utils";
+
+/**
+ * Get the original URL from a known opaque affiliate redirect by following it
+ * cookielessly. Only ever called from the opt-in (resolveOpaque) online path —
+ * the offline pipeline never touches these links.
+ * @param url https://t.afi-b.com/visit.php?guid=ON&a=XXXXX&p=YYYYY etc.
+ */
+export async function getOpaqueRedirectOriginal(url: string): Promise<string> {
+  return await resolveRedirects(url);
+}

--- a/src/core/opaque/index.ts
+++ b/src/core/opaque/index.ts
@@ -1,0 +1,2 @@
+export * from "./isOpaqueRedirect";
+export * from "./getOpaqueRedirectOriginal";

--- a/src/core/opaque/isOpaqueRedirect.spec.ts
+++ b/src/core/opaque/isOpaqueRedirect.spec.ts
@@ -1,0 +1,24 @@
+import { isOpaqueRedirect } from "./isOpaqueRedirect";
+
+describe("isOpaqueRedirect", () => {
+  it.each([
+    ["https://t.afi-b.com/visit.php?guid=ON&a=A1234&p=P5678", true],
+    ["https://t.felmat.net/fmcl?ak=B1234.5678", true],
+    ["https://click.j-a-net.jp/1234567/890123/", true],
+    ["https://px.tcs-asp.net/cl/abcd1234/?bId=xyz", true],
+    ["https://www.rentracks.jp/adx/r.html?idx=12345.67890", true],
+    ["https://www.infotop.jp/click.php?aid=123456&iid=78901", true],
+    ["https://a.r10.to/hN1abc", true],
+    ["https://geni.us/example", true],
+    ["https://hop.clickbank.net/?affiliate=x&vendor=y", true],
+    // 対象ホストでもアフィリエイト用パス以外は除外
+    ["https://www.rentracks.jp/company/about.html", false],
+    ["https://www.infotop.jp/", false],
+    // マーチャント・一般サイトは除外
+    ["https://www.amazon.co.jp/dp/B08JLZV7G1", false],
+    ["https://example.com/visit.php?a=1", false],
+    ["not a url", false],
+  ])("%s", (url, expected) => {
+    expect(isOpaqueRedirect(url)).toBe(expected);
+  });
+});

--- a/src/core/opaque/isOpaqueRedirect.ts
+++ b/src/core/opaque/isOpaqueRedirect.ts
@@ -1,0 +1,40 @@
+/**
+ * 宛先がサーバー側にしか存在しない「不透明リダイレクト」の既知ホスト。
+ * オフラインでは復元できないため、opt-in の hover 解決（Cookieレスの
+ * resolveRedirects）でのみ処理される。マーチャントのドメインは絶対に
+ * 入れないこと — ここに載ったURLはネットワークで辿られる。
+ */
+const OPAQUE_REDIRECT_HOSTS: ReadonlyArray<{ host: string; pathPrefix?: string }> = [
+  { host: "t.afi-b.com" }, // afb
+  { host: "t.felmat.net" }, // felmat
+  { host: "click.j-a-net.jp" }, // JANet
+  { host: "px.tcs-asp.net" }, // TCSアフィリエイト
+  { host: "rentracks.jp", pathPrefix: "/adx/" }, // レントラックス
+  { host: "infotop.jp", pathPrefix: "/click" }, // infotop
+  { host: "a.r10.to" }, // 楽天アフィリエイト短縮リンク
+  { host: "geni.us" }, // Geniuslink
+  { host: "hop.clickbank.net" }, // ClickBank
+];
+
+function hostMatches(hostname: string, host: string): boolean {
+  return hostname === host || hostname.endsWith("." + host);
+}
+
+/**
+ * Check if the url is a known opaque affiliate redirect
+ * @param url https://t.afi-b.com/visit.php?guid=ON&a=XXXXX&p=YYYYY etc.
+ */
+export function isOpaqueRedirect(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+
+    const hostname = parsed.hostname.toLowerCase();
+    return OPAQUE_REDIRECT_HOSTS.some(
+      ({ host, pathPrefix }) =>
+        hostMatches(hostname, host) && (!pathPrefix || parsed.pathname.startsWith(pathPrefix)),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/core/utils/extractEmbeddedUrl.spec.ts
+++ b/src/core/utils/extractEmbeddedUrl.spec.ts
@@ -33,6 +33,72 @@ describe("extractEmbeddedUrl", () => {
         "https://wrap.example/go?ref=abc&url=https://shop.example/first&dest=https://other.example/second";
       expect(extractEmbeddedUrl(input)).toBe("https://shop.example/first");
     });
+
+    it("recognizes network-specific param names (lurl, mpre, urllink, dl_target_url, wgtarget)", () => {
+      expect(
+        extractEmbeddedUrl(
+          "https://al.dmm.co.jp/?lurl=https%3A%2F%2Fwww.dmm.co.jp%2Fdigital%2Fvideoa%2F&af_id=x-001",
+        ),
+      ).toBe("https://www.dmm.co.jp/digital/videoa/");
+      expect(
+        extractEmbeddedUrl(
+          "https://rover.ebay.com/rover/1/711-1234/1?mpre=https%3A%2F%2Fwww.ebay.com%2Fitm%2F123",
+        ),
+      ).toBe("https://www.ebay.com/itm/123");
+      expect(
+        extractEmbeddedUrl(
+          "https://track.webgains.com/click.html?wgcampaignid=1&wgtarget=https://shop.example/p",
+        ),
+      ).toBe("https://shop.example/p");
+      expect(
+        extractEmbeddedUrl(
+          "https://s.click.aliexpress.com/deep_link.htm?aff_short_key=x&dl_target_url=https%3A%2F%2Fwww.aliexpress.com%2Fitem%2F1.html",
+        ),
+      ).toBe("https://www.aliexpress.com/item/1.html");
+    });
+
+    it("accepts scheme-less www. destinations under allowed params (ShareASale urllink)", () => {
+      const input =
+        "https://www.shareasale.com/r.cfm?b=1&u=2&m=3&urllink=www%2Emerchant%2Eexample%2Fproduct%2F42";
+      expect(extractEmbeddedUrl(input)).toBe("https://www.merchant.example/product/42");
+    });
+
+    it("extracts CJ path-embedded deep links (/type/dlg/)", () => {
+      expect(
+        extractEmbeddedUrl(
+          "https://www.anrdoezrs.net/links/9041660/type/dlg/https://www.merchant.example/product?a=1",
+        ),
+      ).toBe("https://www.merchant.example/product?a=1");
+      expect(
+        extractEmbeddedUrl(
+          "https://www.dpbolvw.net/links/123/type/dlg/https%3A%2F%2Fshop.example%2Fp",
+        ),
+      ).toBe("https://shop.example/p");
+    });
+
+    it("extracts Partnerize path-embedded deep links (/destination:)", () => {
+      expect(
+        extractEmbeddedUrl(
+          "https://brand.prf.hn/click/camref:1101abc/destination:https%3A%2F%2Fwww.merchant.example%2Fitem%3Fcolor%3Dred",
+        ),
+      ).toBe("https://www.merchant.example/item?color=red");
+    });
+
+    it("resolves the short `u` param only on curated wrapper hosts (viglink, l.facebook)", () => {
+      expect(
+        extractEmbeddedUrl(
+          "https://redirect.viglink.com/?key=abc&u=https%3A%2F%2Fshop.example%2Fx",
+        ),
+      ).toBe("https://shop.example/x");
+      expect(
+        extractEmbeddedUrl(
+          "https://l.facebook.com/l.php?u=https%3A%2F%2Fnews.example%2Farticle&h=AT0x",
+        ),
+      ).toBe("https://news.example/article");
+      expect(
+        extractEmbeddedUrl("https://l.instagram.com/?u=https%3A%2F%2Fshop.example%2Fp&e=AT1y"),
+      ).toBe("https://shop.example/p");
+    });
   });
 
   describe("does not rewrite legitimate links (negative cases)", () => {
@@ -99,6 +165,19 @@ describe("extractEmbeddedUrl", () => {
     it("returns null for invalid input", () => {
       expect(extractEmbeddedUrl("not a url")).toBeNull();
       expect(extractEmbeddedUrl("")).toBeNull();
+    });
+
+    it("ignores path markers whose value is not a cross-host URL", () => {
+      expect(extractEmbeddedUrl("https://x.example/links/1/type/dlg/12345")).toBeNull();
+      expect(
+        extractEmbeddedUrl("https://brand.prf.hn/click/camref:1/destination:not-a-url"),
+      ).toBeNull();
+    });
+
+    it("does not honor `u` on hosts outside the curated override list", () => {
+      expect(
+        extractEmbeddedUrl("https://unknown.example/out?u=https%3A%2F%2Fshop.example%2Fx"),
+      ).toBeNull();
     });
 
     it("ignores non-http(s) embedded values (e.g. javascript:, mailto:)", () => {

--- a/src/core/utils/extractEmbeddedUrl.ts
+++ b/src/core/utils/extractEmbeddedUrl.ts
@@ -27,7 +27,38 @@ const REDIRECT_PARAM_NAMES = new Set([
   "view_url",
   "a8ejpre",
   "a8ejpredirect",
+  // ネットワーク固有だが名前の識別性が高く、グローバル適用しても安全なもの
+  "lurl", // DMMアフィリエイト (al.dmm.co.jp/?lurl=...)
+  "mpre", // eBay Partner Network (rover.ebay.com ...&mpre=...)
+  "urllink", // ShareASale (shareasale.com/r.cfm?...&urllink=...)
+  "dl_target_url", // AliExpress (s.click.aliexpress.com/deep_link.htm)
+  "wgtarget", // Webgains (track.webgains.com/click.html?...&wgtarget=...)
 ]);
+
+/**
+ * 「u」のような短く曖昧な名前は、グローバルには適用できない（OAuth等を壊す）が、
+ * 宛先パラメータであることが確実な特定ホストに限れば安全に復元できる。
+ * SNSの outbound クリック計測ラッパー（l.facebook.com 等）もここで剥がす —
+ * シェア「インテント」(facebook.com/sharer) と違い、これらは単なる追跡付き
+ * リダイレクトなので直リンク化はページを壊さない。
+ */
+const HOST_PARAM_OVERRIDES = new Map<string, Set<string>>([
+  ["redirect.viglink.com", new Set(["u"])], // VigLink / Sovrn
+  ["l.facebook.com", new Set(["u"])],
+  ["lm.facebook.com", new Set(["u"])],
+  ["l.instagram.com", new Set(["u"])],
+  ["l.messenger.com", new Set(["u"])],
+]);
+
+/**
+ * クエリではなくパス末尾に宛先URLを連結する「パス埋め込み」ディープリンク形式。
+ * マーカー自体の識別性が高く、抽出値も通常の検証（別ホストの絶対 http(s) URL）を
+ * 通すため、ホスト非依存で安全に適用できる。
+ *  - CJ (Commission Junction): https://www.anrdoezrs.net/links/<id>/type/dlg/<URL>
+ *    (dpbolvw.net / tkqlhce.com / kqzyfj.com / jdoqocy.com も同形式)
+ *  - Partnerize: https://<brand>.prf.hn/click/camref:<id>/destination:<URL>
+ */
+const PATH_EMBED_MARKERS = ["/type/dlg/", "/destination:"];
 
 /**
  * `url=` 系のパラメータを持つが「リダイレクトではない」ホスト
@@ -72,15 +103,43 @@ function decodeMaybe(value: string): string {
 }
 
 /**
- * ラッパーURLのクエリパラメータから、埋め込まれた宛先URLをオフラインで抽出する。
+ * 候補文字列を検証し、合格すれば正規化済みの宛先URLを返す。
+ * 条件: （最大3回デコード後に）絶対 http(s) URL で、ラッパーと異なるホストであること。
+ * 同一ホストへの遷移は「次へ」「戻る」等のナビゲーション用パラメータの可能性が高く、
+ * アフィリエイトのクロスサイトリダイレクトではないため除外する。
+ */
+function validateCandidate(rawValue: string, wrapperHost: string): string | null {
+  if (!rawValue) return null;
+
+  let candidate = decodeMaybe(rawValue);
+  // ShareASale の urllink= 等はスキーム無し（www.merchant.com/...）で宛先を載せる。
+  // 許可済みパラメータ/マーカーの値に限った補完なので誤検知リスクは低い。
+  if (/^www\./i.test(candidate)) candidate = "https://" + candidate;
+  candidate = fixIncompleteUrl(candidate);
+  if (!/^https?:\/\//i.test(candidate)) return null;
+
+  let embedded: URL;
+  try {
+    embedded = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  if (embedded.hostname.toLowerCase() === wrapperHost) return null;
+
+  return embedded.toString();
+}
+
+/**
+ * ラッパーURLから、埋め込まれた宛先URLをオフラインで抽出する。
  * ネットワークリクエストを一切発生させない純粋関数。
  *
- * 以下を全て満たす場合のみ宛先を返す（さもなくば null）:
- *  1. URL としてパースできる
- *  2. ホストが除外リストに無い
- *  3. リダイレクト系のパラメータ名を持つ
- *  4. その値が（最大3回デコード後に）絶対 http(s) URL である
- *  5. 抽出先のホストがラッパーと異なる（同一サイト内ナビゲーション用パラメータの誤検知防止）
+ * 抽出元は次の3系統（上から順に試す）:
+ *  a. グローバル許可リストのクエリパラメータ（REDIRECT_PARAM_NAMES）
+ *  b. ホスト限定の短い名前（HOST_PARAM_OVERRIDES — viglink/l.facebook 等の `u`）
+ *  c. パス埋め込み形式（PATH_EMBED_MARKERS — CJ `/type/dlg/`、Partnerize `/destination:`）
+ *
+ * いずれも値が検証（validateCandidate: 別ホストの絶対 http(s) URL）を通った場合のみ返す。
  *
  * @param url 例: https://unknown-asp.example/redirect?url=https%3A%2F%2Fshop.example%2Fitem
  */
@@ -97,27 +156,22 @@ export function extractEmbeddedUrl(url: string): string | null {
     return null;
   }
 
+  const hostParams = HOST_PARAM_OVERRIDES.get(wrapperHost);
+
   for (const [name, rawValue] of wrapper.searchParams.entries()) {
-    if (!REDIRECT_PARAM_NAMES.has(name.toLowerCase())) continue;
-    if (!rawValue) continue;
+    const paramName = name.toLowerCase();
+    if (!REDIRECT_PARAM_NAMES.has(paramName) && !hostParams?.has(paramName)) continue;
 
-    const candidate = fixIncompleteUrl(decodeMaybe(rawValue));
-    if (!/^https?:\/\//i.test(candidate)) continue;
+    const embedded = validateCandidate(rawValue, wrapperHost);
+    if (embedded) return embedded;
+  }
 
-    let embedded: URL;
-    try {
-      embedded = new URL(candidate);
-    } catch {
-      continue;
-    }
+  for (const marker of PATH_EMBED_MARKERS) {
+    const index = url.indexOf(marker);
+    if (index === -1) continue;
 
-    // 同一ホストへの遷移は「次へ」「戻る」等のナビゲーション用パラメータの可能性が高く、
-    // アフィリエイトのクロスサイトリダイレクトではないため除外する。
-    if (embedded.hostname.toLowerCase() === wrapperHost) {
-      continue;
-    }
-
-    return embedded.toString();
+    const embedded = validateCandidate(url.slice(index + marker.length), wrapperHost);
+    if (embedded) return embedded;
   }
 
   return null;

--- a/src/core/utils/purifyResolvedUrl.spec.ts
+++ b/src/core/utils/purifyResolvedUrl.spec.ts
@@ -56,6 +56,25 @@ describe("purifyResolvedUrl", () => {
     expect(purifyResolvedUrl(input)).toBe(input);
   });
 
+  it("removes ValueCommerce attribution (sc_e) from Yahoo! Shopping urls", () => {
+    const input =
+      "https://store.shopping.yahoo.co.jp/shop/item.html?sc_e=afvc_xyz_123&sc_i=shp_pc&color=red";
+    expect(purifyResolvedUrl(input)).toBe(
+      "https://store.shopping.yahoo.co.jp/shop/item.html?color=red",
+    );
+  });
+
+  it("keeps sc_e on non-shopping yahoo domains", () => {
+    const input = "https://news.yahoo.co.jp/articles/abc?sc_e=xyz";
+    expect(purifyResolvedUrl(input)).toBe(input);
+  });
+
+  it("removes eBay Partner Network params from ebay domains", () => {
+    const input =
+      "https://www.ebay.com/itm/123456?mkcid=1&mkrid=711-53200-19255-0&campid=5338&customid=x&toolid=10001&hash=item1";
+    expect(purifyResolvedUrl(input)).toBe("https://www.ebay.com/itm/123456?hash=item1");
+  });
+
   it("strips generic tracking params on any domain", () => {
     expect(purifyResolvedUrl("https://news.example/article?utm_source=tw&gclid=abc&id=5")).toBe(
       "https://news.example/article?id=5",

--- a/src/core/utils/purifyResolvedUrl.spec.ts
+++ b/src/core/utils/purifyResolvedUrl.spec.ts
@@ -33,6 +33,29 @@ describe("purifyResolvedUrl", () => {
     expect(purifyResolvedUrl(input)).toBe(input);
   });
 
+  it("removes associate params on every amazon TLD", () => {
+    expect(purifyResolvedUrl("https://www.amazon.com/dp/B0?tag=x-20&linkId=abc&th=1")).toBe(
+      "https://www.amazon.com/dp/B0?th=1",
+    );
+    expect(purifyResolvedUrl("https://www.amazon.de/dp/B0?tag=x-21&ascsubtag=s")).toBe(
+      "https://www.amazon.de/dp/B0",
+    );
+  });
+
+  it("strips the trailing /ref= attribution path segment on amazon", () => {
+    expect(purifyResolvedUrl("https://www.amazon.co.jp/dp/B08JLZV7G1/ref=nosim?tag=x-22")).toBe(
+      "https://www.amazon.co.jp/dp/B08JLZV7G1",
+    );
+    expect(purifyResolvedUrl("https://www.amazon.co.jp/dp/B08JLZV7G1/ref=as_li_ss_tl")).toBe(
+      "https://www.amazon.co.jp/dp/B08JLZV7G1",
+    );
+  });
+
+  it("keeps /ref= path segments on non-amazon domains", () => {
+    const input = "https://example.com/dp/B08JLZV7G1/ref=nosim";
+    expect(purifyResolvedUrl(input)).toBe(input);
+  });
+
   it("strips generic tracking params on any domain", () => {
     expect(purifyResolvedUrl("https://news.example/article?utm_source=tw&gclid=abc&id=5")).toBe(
       "https://news.example/article?id=5",

--- a/src/core/utils/purifyResolvedUrl.ts
+++ b/src/core/utils/purifyResolvedUrl.ts
@@ -31,28 +31,64 @@ const AMAZON_AFFILIATE_PARAMS = [
   "asc_source",
 ];
 
-function purifyResolvedRakutenUrl(url: string, urlObj: URL): string {
-  if (!isRakutenDomain(urlObj.hostname)) return url;
-
-  const hasScid = urlObj.searchParams.has("scid");
-  const hasSc2id = urlObj.searchParams.has("sc2id");
-  if (!hasScid && !hasSc2id) return url;
-
-  urlObj.searchParams.delete("scid");
-  urlObj.searchParams.delete("sc2id");
-  return urlObj.toString();
+/** Yahoo!ショッピング系ホスト（store.shopping.yahoo.co.jp 等のサブドメイン含む）。 */
+function isYahooShoppingDomain(hostname: string): boolean {
+  return (
+    hostname === "shopping.yahoo.co.jp" ||
+    hostname.endsWith(".shopping.yahoo.co.jp") ||
+    hostname === "paypaymall.yahoo.co.jp" ||
+    hostname.endsWith(".paypaymall.yahoo.co.jp")
+  );
 }
 
-function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
-  if (!isAmazonDomain(urlObj.hostname)) return url;
+/** eBay retail TLDs (for EPN attribution params). */
+const ebayHostRegex =
+  /(^|\.)ebay\.(com|co\.uk|de|fr|it|es|ca|nl|at|ch|ie|pl|be|com\.au|com\.hk|com\.sg|com\.my|co\.jp|ph)$/;
 
+/** eBay Partner Network / campaign attribution params — not functional. */
+const EBAY_AFFILIATE_PARAMS = [
+  "mkcid",
+  "mkevt",
+  "mkrid",
+  "mkpid",
+  "campid",
+  "customid",
+  "toolid",
+  "ssspo",
+  "sssrc",
+  "ssuid",
+];
+
+/** Delete the given params; returns the original string when nothing matched. */
+function deleteParams(url: string, urlObj: URL, params: readonly string[]): string {
   let changed = false;
-  for (const param of AMAZON_AFFILIATE_PARAMS) {
+  for (const param of params) {
     if (urlObj.searchParams.has(param)) {
       urlObj.searchParams.delete(param);
       changed = true;
     }
   }
+  return changed ? urlObj.toString() : url;
+}
+
+function purifyResolvedRakutenUrl(url: string, urlObj: URL): string {
+  if (!isRakutenDomain(urlObj.hostname)) return url;
+  return deleteParams(url, urlObj, ["scid", "sc2id"]);
+}
+
+function purifyResolvedYahooShoppingUrl(url: string, urlObj: URL): string {
+  if (!isYahooShoppingDomain(urlObj.hostname)) return url;
+  // sc_e: ValueCommerce経由の帰属タグ (afvc_...) / sc_i: Yahoo内部クリック計測
+  return deleteParams(url, urlObj, ["sc_e", "sc_i"]);
+}
+
+function purifyResolvedEbayUrl(url: string, urlObj: URL): string {
+  if (!ebayHostRegex.test(urlObj.hostname)) return url;
+  return deleteParams(url, urlObj, EBAY_AFFILIATE_PARAMS);
+}
+
+function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
+  if (!isAmazonDomain(urlObj.hostname)) return url;
 
   // SiteStripe/associate links carry an attribution breadcrumb as the final
   // path segment (/dp/ASIN/ref=nosim, .../ref=as_li_ss_tl). Product pages work
@@ -60,19 +96,22 @@ function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
   const refMatch = /^(.*)\/ref=[^/]*\/?$/.exec(urlObj.pathname);
   if (refMatch) {
     urlObj.pathname = refMatch[1] || "/";
-    changed = true;
+    return deleteParams(urlObj.toString(), urlObj, AMAZON_AFFILIATE_PARAMS);
   }
 
-  return changed ? urlObj.toString() : url;
+  return deleteParams(url, urlObj, AMAZON_AFFILIATE_PARAMS);
 }
 
 export function purifyResolvedUrl(url: string): string {
   try {
     // 1. Domain-agnostic: strip well-known tracking query params (utm_*, gclid,
-    //    fbclid, ...). 2. Domain-specific affiliate tags (Rakuten, Amazon).
+    //    fbclid, ...). 2. Domain-specific affiliate tags (Rakuten, Amazon,
+    //    Yahoo!ショッピング, eBay).
     let result = stripTrackingParams(url);
     result = purifyResolvedRakutenUrl(result, new URL(result));
     result = purifyResolvedAmazonUrl(result, new URL(result));
+    result = purifyResolvedYahooShoppingUrl(result, new URL(result));
+    result = purifyResolvedEbayUrl(result, new URL(result));
     return result;
   } catch {
     return url;

--- a/src/core/utils/purifyResolvedUrl.ts
+++ b/src/core/utils/purifyResolvedUrl.ts
@@ -6,9 +6,30 @@ function isRakutenDomain(hostname: string): boolean {
   return hostname === "rakuten.co.jp" || hostname.endsWith(rakutenHostSuffix);
 }
 
+/** Every Amazon retail TLD (amazon.co.jp, amazon.com, amazon.de, ...). */
+const amazonHostRegex =
+  /(^|\.)amazon\.(com|co\.jp|co\.uk|de|fr|it|es|ca|cn|in|nl|se|pl|sg|ae|sa|eg|com\.au|com\.br|com\.mx|com\.tr|com\.be)$/;
+
 function isAmazonDomain(hostname: string): boolean {
-  return hostname === "amazon.co.jp" || hostname.endsWith(".amazon.co.jp");
+  return amazonHostRegex.test(hostname);
 }
+
+/**
+ * Amazon Associates attribution params. All are commission/campaign metadata —
+ * none affect which product page is shown, so removing them is lossless.
+ */
+const AMAZON_AFFILIATE_PARAMS = [
+  "tag",
+  "linkCode",
+  "linkId",
+  "creative",
+  "creativeASIN",
+  "camp",
+  "ascsubtag",
+  "asc_campaign",
+  "asc_refurl",
+  "asc_source",
+];
 
 function purifyResolvedRakutenUrl(url: string, urlObj: URL): string {
   if (!isRakutenDomain(urlObj.hostname)) return url;
@@ -25,13 +46,24 @@ function purifyResolvedRakutenUrl(url: string, urlObj: URL): string {
 function purifyResolvedAmazonUrl(url: string, urlObj: URL): string {
   if (!isAmazonDomain(urlObj.hostname)) return url;
 
-  const hasTag = urlObj.searchParams.has("tag");
-  const hasLinkCode = urlObj.searchParams.has("linkCode");
-  if (!hasTag && !hasLinkCode) return url;
+  let changed = false;
+  for (const param of AMAZON_AFFILIATE_PARAMS) {
+    if (urlObj.searchParams.has(param)) {
+      urlObj.searchParams.delete(param);
+      changed = true;
+    }
+  }
 
-  urlObj.searchParams.delete("tag");
-  urlObj.searchParams.delete("linkCode");
-  return urlObj.toString();
+  // SiteStripe/associate links carry an attribution breadcrumb as the final
+  // path segment (/dp/ASIN/ref=nosim, .../ref=as_li_ss_tl). Product pages work
+  // identically without it.
+  const refMatch = /^(.*)\/ref=[^/]*\/?$/.exec(urlObj.pathname);
+  if (refMatch) {
+    urlObj.pathname = refMatch[1] || "/";
+    changed = true;
+  }
+
+  return changed ? urlObj.toString() : url;
 }
 
 export function purifyResolvedUrl(url: string): string {

--- a/src/core/utils/stripTrackingParams.spec.ts
+++ b/src/core/utils/stripTrackingParams.spec.ts
@@ -18,6 +18,17 @@ describe("stripTrackingParams", () => {
     expect(stripTrackingParams(input)).toBe("https://shop.example/p?ok=1");
   });
 
+  it("removes affiliate-network click-ids used for cookieless attribution", () => {
+    const input =
+      "https://shop.example/p?cjevent=abc&irclickid=def&sscid=ghi&awc=123_456&srsltid=AfmBOo&keep=1";
+    expect(stripTrackingParams(input)).toBe("https://shop.example/p?keep=1");
+  });
+
+  it("removes Rakuten Advertising deep-link params (ranMID/ranEAID/ranSiteID)", () => {
+    const input = "https://shop.example/item?ranMID=1234&ranEAID=abc&ranSiteID=xyz-_-&id=5";
+    expect(stripTrackingParams(input)).toBe("https://shop.example/item?id=5");
+  });
+
   it("removes the query string entirely when only tracking params remain", () => {
     expect(stripTrackingParams("https://shop.example/p?utm_source=x&fbclid=y")).toBe(
       "https://shop.example/p",

--- a/src/core/utils/stripTrackingParams.ts
+++ b/src/core/utils/stripTrackingParams.ts
@@ -31,6 +31,18 @@ const TRACKING_PARAMS = new Set([
   "twclid",
   "ttclid",
   "li_fat_id",
+  // Affiliate-network click-ids appended to MERCHANT urls for server-side
+  // (cookieless) attribution. Names are network-specific, so removing them
+  // globally is safe — and it cuts attribution the cookie cleaner can't reach.
+  "srsltid", // Google Merchant Center auto-tagging
+  "cjevent", // Commission Junction
+  "cjdata",
+  "irclickid", // Impact
+  "sscid", // ShareASale
+  "awc", // Awin
+  "ranmid", // Rakuten Advertising / LinkShare deep links
+  "raneaid",
+  "ransiteid",
   // misc analytics click-ids
   "_openstat",
   "vero_id",

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -67,6 +67,10 @@ async function init() {
       const isEnabled = changes[SETTINGS_KEYS.ENABLED].newValue === true;
       if (isEnabled) {
         startProcessing();
+        // resolveOpaque is still on in storage — bring its resolver back too.
+        loadSettings().then(({ resolveOpaque }) => {
+          if (resolveOpaque) opaqueResolver.start();
+        });
       } else {
         stopProcessing();
         opaqueResolver.stop();

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -1,10 +1,13 @@
 import { SETTINGS_KEYS, loadSettings } from "@/services/settings";
-import { createLinkRewriter } from "@/services/rewriteLinks";
+import { createClickGuard, createLinkRewriter } from "@/services/rewriteLinks";
 import { createOpaqueResolver } from "@/services/opaqueResolver";
 
 // Pure, synchronous, network-free rewriting — resolving every link on the page
 // triggers no affiliate clicks/conversions.
 const { rewriteAnchor, rewriteWithin } = createLinkRewriter();
+// Last-moment re-rewrite on click, for sites that swap the href back to the
+// affiliate URL on mousedown/click.
+const clickGuard = createClickGuard(rewriteAnchor);
 // Opt-in: cookieless on-hover resolution of opaque-token links (network).
 const opaqueResolver = createOpaqueResolver();
 let observer: MutationObserver | null = null;
@@ -40,6 +43,7 @@ function observeAnchors() {
 function startProcessing() {
   rewriteWithin(document);
   observeAnchors();
+  clickGuard.start();
 }
 
 function stopProcessing() {
@@ -47,6 +51,7 @@ function stopProcessing() {
     observer.disconnect();
     observer = null;
   }
+  clickGuard.stop();
 }
 
 async function init() {

--- a/src/services/rewriteLinks.spec.ts
+++ b/src/services/rewriteLinks.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createLinkRewriter } from "./rewriteLinks";
+import { createClickGuard, createLinkRewriter } from "./rewriteLinks";
 
 describe("createLinkRewriter", () => {
   beforeEach(() => {
@@ -51,5 +51,59 @@ describe("createLinkRewriter", () => {
     // Re-running on the now-resolved anchor must leave it stable (no loop).
     rewriter.rewriteAnchor(a);
     expect(a.href).toBe("https://shop.example/p");
+  });
+});
+
+describe("createClickGuard", () => {
+  const AFFILIATE = "https://unknown-asp.example/redirect?url=https%3A%2F%2Fshop.example%2Fitem";
+  const CLEAN = "https://shop.example/item";
+
+  let anchor: HTMLAnchorElement;
+  let guard: ReturnType<typeof createClickGuard>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    anchor = document.createElement("a");
+    document.body.appendChild(anchor);
+    // keep jsdom from attempting real navigation on unhandled clicks
+    document.body.addEventListener("click", (e) => e.preventDefault());
+
+    guard = createClickGuard(createLinkRewriter().rewriteAnchor);
+    guard.start();
+  });
+
+  it("re-rewrites an href swapped to an affiliate url on mousedown", () => {
+    anchor.href = CLEAN;
+    anchor.addEventListener("mousedown", () => {
+      anchor.href = AFFILIATE;
+    });
+
+    anchor.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(anchor.href).toBe(AFFILIATE); // the cloaker won the mousedown...
+
+    anchor.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(anchor.href).toBe(CLEAN); // ...but the click guard wins the click
+
+    guard.stop();
+  });
+
+  it("re-rewrites when the swap happens inside the anchor's own click handler", () => {
+    anchor.href = CLEAN;
+    anchor.addEventListener("click", () => {
+      anchor.href = AFFILIATE;
+    });
+
+    anchor.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(anchor.href).toBe(CLEAN); // document-level bubble listener ran last
+
+    guard.stop();
+  });
+
+  it("does nothing after stop()", () => {
+    guard.stop();
+    anchor.href = AFFILIATE;
+
+    anchor.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(anchor.href).toBe(AFFILIATE);
   });
 });

--- a/src/services/rewriteLinks.ts
+++ b/src/services/rewriteLinks.ts
@@ -35,3 +35,48 @@ export function createLinkRewriter() {
 
   return { rewriteAnchor, rewriteWithin };
 }
+
+/**
+ * Final safety net for sites that keep a clean href and swap in the affiliate
+ * URL only at interaction time (onmousedown / click handlers), defeating
+ * one-shot rewriting. Re-running the cached, synchronous offline rewrite during
+ * click/auxclick dispatch wins that race: it runs after their swap but before
+ * the browser follows the link.
+ *
+ * Registered in BOTH phases: capture (fires even if a handler later stops
+ * propagation) and bubble at the document root (fires after the target's own
+ * click handlers, catching swaps done inside them).
+ */
+export function createClickGuard(rewriteAnchor: (anchor: HTMLAnchorElement) => void) {
+  const CLICK_EVENTS = ["click", "auxclick"] as const;
+  let listening = false;
+
+  function handleClick(event: Event) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const anchor = target.closest("a");
+    if (anchor instanceof HTMLAnchorElement) {
+      rewriteAnchor(anchor);
+    }
+  }
+
+  function start() {
+    if (listening) return;
+    listening = true;
+    for (const type of CLICK_EVENTS) {
+      document.addEventListener(type, handleClick, { capture: true });
+      document.addEventListener(type, handleClick, { capture: false });
+    }
+  }
+
+  function stop() {
+    if (!listening) return;
+    listening = false;
+    for (const type of CLICK_EVENTS) {
+      document.removeEventListener(type, handleClick, { capture: true });
+      document.removeEventListener(type, handleClick, { capture: false });
+    }
+  }
+
+  return { start, stop };
+}


### PR DESCRIPTION
## 概要

オフライン優先の設計はそのままに、アフィリエイト除去のカバレッジを広げる7改善+1バグ修正(8コミット、改善ごとに自己完結)。

1. **Amazon強化**: purifyを全Amazon TLDに拡大(従来は`amazon.co.jp`のみ)。`tag`/`linkCode`に加え`linkId`/`creative`/`creativeASIN`/`camp`/`ascsubtag`/`asc_*`を除去し、SiteStripeが付ける末尾`/ref=`帰属パスセグメントも削除。`amzn.asia`短縮リンクも検出対象に。
2. **click-idのグローバル除去**: `srsltid`(Google Merchant)/`cjevent`・`cjdata`(CJ)/`irclickid`(Impact)/`sscid`(ShareASale)/`awc`(Awin)/`ranMID`・`ranEAID`・`ranSiteID`(Rakuten Advertising)。**Cookie削除では届かないサーバーサイド帰属**を遮断する。名前がネットワーク固有なのでグローバル除去でも安全。
3. **埋め込みURL抽出の拡張**: CJ `/type/dlg/<URL>`・Partnerize `/destination:<URL>`の**パス埋め込み形式**をオフライン復元。識別性の高いパラメータ`lurl`(DMM)/`mpre`(eBay)/`urllink`(ShareASale、スキーム無し`www.`値対応)/`dl_target_url`(AliExpress)/`wgtarget`(Webgains)を追加。短い`u`は**ホスト限定**(redirect.viglink.com、l.facebook.com / l.instagram.com / l.messenger.com のoutboundラッパー)でのみ採用。シェアインテントは従来通り除外。
4. **マーチャント別purify**: Yahoo!ショッピングの`sc_e`(ValueCommerce帰属)/`sc_i`、eBay各国ドメインの`mkcid`/`mkevt`/`mkrid`/`campid`/`customid`/`toolid`等。共通`deleteParams`ヘルパーを抽出。
5. **クリック直前ガード**: mousedown/clickハンドラでhrefをアフィURLへ差し替え直すクローキング対策。click/auxclickのcapture+bubble両段でキャッシュ済みオフライン書き換えを同期再実行(通信ゼロ)。
6. **fix: 再有効化バグ**: 拡張をOFF→ONしたとき、`resolveOpaque=true`でもhover解決が復帰しなかった。
7. **CookieクリーナーASP拡大**: 国内 JANet / TCS / レントラックス / infotop / Zucks(mobu.jp) / Smart-C、グローバル Impact(sjv.io / pxf.io / evyy.net / 7eer.net) / ClickBank / Tradedoubler / Webgains / VigLink。すべてアフィリエイト専用インフラのみ(マーチャントドメインなし)。
8. **不透明リンクhover解決の対象拡大**: afb / felmat / JANet / TCS / レントラックス / `a.r10.to`(楽天短縮) / geni.us / ClickBankを汎用opaqueプロバイダとしてaffiliateMap末尾に登録。`a.r10.to`は解決後にrakutenプロバイダへ連鎖し`pc=`抽出まで到達。

## 設計方針(維持)

- 既定はstrict offline-only: 通信が発生するのはopt-in(`resolveOpaque`)経路のみ。ファントムクリックなし。
- 誤検知ガード: 「別ホストの絶対http(s) URL」のみ採用、曖昧な短い名前はホスト限定、SNSシェアインテント/翻訳プロキシは除外を維持。
- Cookie削除はASPインフラ限定(`afl.rakuten.co.jp`方式のサブドメイン限定も維持)。

## テスト

- `pnpm test`: **194 pass / 1 skip**(35ファイル)。各改善に対応するspec追加(amazon全TLD・`/ref=`、click-id、CJ/Partnerize/ホスト限定`u`、Yahoo/eBay、クリックガードのクローキング3シナリオ、opaqueプロバイダ)。
- `pnpm run compile` / `pnpm run build` / `pnpm run build:firefox` / Prettier すべてOK。